### PR TITLE
parse compat when .tag is after attributes in api response

### DIFF
--- a/src/parser.g
+++ b/src/parser.g
@@ -4,6 +4,7 @@ start
 
 packet
   = re s tag:tag s data:data+ { return {type: "data", id:tag, data:data, tag:tag} }
+  / re s data:data+ s tag:tag s { return {type: "data", id:tag, data:data, tag:tag} }
   / re s data:data+ e:end s { return {type: e.type, id:e.id, data:data, tag:tag} }
   / e:end s {return e}
 
@@ -28,7 +29,7 @@ end
   / "!done"                                   {return {type: "done" }}
   / tag:tag                                   {return {type: "tag", id:tag }}
 
-tag 
+tag
   = ".tag=" id:[a-zA-Z_\-0-9]+ {return id.join('')}
 
 trap


### PR DESCRIPTION
In some scenarios RouterOS will return the .tag towards the end of the response after the attributes.

```
!re
=.id=5
=address=1.2.3.4/24
.tag=mytag

!done
```

This trips the parser and fatal "tag not found" gets thrown.

First time looking at pegjs, please forgive any ignorance 
