### PR TITLE
Resolved #47. Print requires pre-formatted.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 node_modules
 dist
+examples
+test
+.vscode
+.jshintrc
+jsconfig.json
+webpack.config.babel.js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mikronode",
   "description": "Mikrotik API implemented in Node",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "author": "Brandon Myers <trakkasure@gmail.com>",
   "scripts": {
     "build": "webpack --color --progress",

--- a/src/Util.js
+++ b/src/Util.js
@@ -177,10 +177,9 @@ function getUnwrappedPromise() {
 }
 
 function objToAPIParams(obj,type) {
-    const prefix=type==='print'?'?':'=';
-    const t=RegExp("[a-zA-Z]");
+    const prefix=type==='print'?'':'=';
     return Object.keys(obj)
-        .map(k=>obj[k]?`${t.test(k[0])?prefix:""}${k}=${obj[k]}`:`${t.test(k[0])?prefix:""}${k}`);
+        .map(k=>obj[k]?`${prefix}${k}=${obj[k]}`:`${prefix}${k}`);
 }
 
 function resultsToObj(r) {

--- a/src/index.js
+++ b/src/index.js
@@ -417,7 +417,7 @@ class SocketStream {
     write(data,args) {
         if (args && typeof(args)===typeof({}))  {
             this.debug>=DEBUG.SILLY&&console.log("Converting obj to args",args);
-            data=data.concat(objToAPIParams(args,data[0].split('/').pop()));
+            data=data.concat(Array.isArray(args)?args:objToAPIParams(args,data[0].split('/').pop()));
         }
         this.debug>=DEBUG.DEBUG&&console.log('SocketStream::write:',[data]);
         if (!this.socket||!(this.status&(CONNECTION.CONNECTED|CONNECTION.CONNECTING))) {


### PR DESCRIPTION
Added ability to pass preformated arguments using array instead of object.
When using print commands, the arguments should be an array. This ensures proper order of setting query stack.