### PR TITLE
fixing function refs for events in channel.js

### DIFF
--- a/src/Channel.js
+++ b/src/Channel.js
@@ -509,19 +509,19 @@ export default class Channel extends events.EventEmitter {
 
     on(event,func) {
         const ret=super.on(event,func);
-        setupEventSubscription(event,getStreamByEventType(event));
+        this.setupEventSubscription(event,this.getStreamByEventType(event));
         return ret;
     }
 
     addEventListener(event,func) {
         const ret=super.addEventListener(event,func);
-        setupEventSubscription(event,getStreamByEventType(event));
+        this.setupEventSubscription(event,this.getStreamByEventType(event));
         return ret;
     }
 
     once(event,func) {
         const ret=super.once(event,func);
-        setupEventSubscription(event,getStreamByEventType(event));
+        this.setupEventSubscription(event,this.getStreamByEventType(event));
         return ret;
     }
 


### PR DESCRIPTION
i get the following with npm mikronode:latest/2.3.6 just by following base examples
`
ReferenceError: setupEventSubscription is not defined
    at Channel.on (node_modules/mikronode/dist/mikronode.js:23359:14)
`