### PR TITLE
[Implementation] Added a newMethod flag to support v6.45.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 dist
-test
 .vscode
 .jshintrc
 jsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test
 .jshintrc
 jsconfig.json
 src/parser.js
+package-lock.json

--- a/Readme.md
+++ b/Readme.md
@@ -112,6 +112,15 @@ With the above code, the following is API description. conn is Connection object
   * conn.getHost()
   * conn.getUser()
 
+### Login
+  The login function receives 3 parameters (username: String, password: String, newMethod: Boolean), if the newMethod is set to True, it will use the login method introduced at [v6.43](https://forum.mikrotik.com/viewtopic.php?f=21&t=138995) and made obligatory at [v6.45.1](https://forum.mikrotik.com/viewtopic.php?f=21&t=149786).
+```javascript
+    var MikroNode = require('mikronode');
+    var Device =new MikroNode(host,port);
+    Device.connect().then(([login])=>login('admin','password', true)).then(function(conn) { 
+        var chan=conn.openChannel();
+    });
+```
 
 ### Channel
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "chai": "^3.5.0",
     "core-decorators": "^0.12.3",
     "mocha": ">=1.7.4",
-    "rxjs": "^5.3.0",
+    "pegjs": "^0.10.0",
+    "promise": "^8.0.3",
+    "rxjs": "^5.5.12",
     "simple-assign": "^0.1.0",
     "uglify-js": ">=1.2.5",
     "webpack": "^1.13.1",
@@ -55,5 +57,6 @@
   "main": "dist/mikronode.js",
   "engines": {
     "node": ">= 6"
-  }
+  },
+  "dependencies": {}
 }

--- a/test/testNewLogin.js
+++ b/test/testNewLogin.js
@@ -1,0 +1,12 @@
+
+var api=require('../dist/mikronode.js');
+
+var device=new api(/* Host */'127.0.0.1' /*, Port */ /*, Timeout */);
+// device.setDebug(api.DEBUG);
+
+// connect:
+device.connect().then(([login])=>login('username','password')).then(function(conn) {
+    console.log("Logged in");
+},function(err) {
+  console.log("Error connecting:",err);
+});


### PR DESCRIPTION
In the version [6.43](https://forum.mikrotik.com/viewtopic.php?f=21&t=138995) the api auth method was changed but it was only on version [6.45.1](https://forum.mikrotik.com/viewtopic.php?f=21&t=149786) released on 01/07/19 that it was made obligatory. This pull request adds a flag on the login function to be able to do login on the new version.

This implementation is not the best because i couldn't fully understand how the connection process works and my time was short. 

But i tested on both versions and it seems to work fine.
I've also added info on the Readme and added a file to test the new auth method.